### PR TITLE
make the unexpected_internal_errror output smaller

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -49,7 +49,7 @@ export def get-latest-nightly-build [
             msg: (
                   $"(ansi red_bold)unexpected_internal_error(ansi reset):\n"
                 + $"expected one match, found ($target | length)\n"
-                + $"matches: ($target)"
+                + $"matches: ($target.name)"
             )
         }
     }


### PR DESCRIPTION
Can we simplify the `matches: ....`  message? It's too long I think

_Originally posted by @hustcer in https://github.com/nushell/nightly/issues/12#issuecomment-1761596998_

## description
when there is an `unexpected_internal_error` in `tk get-latest-nightly-build`, the output is too long.

this PR tries to make it more digest by only showing the names.