### PR TITLE
add non-interactive install to the install script

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -17,7 +17,8 @@ export def get-latest-nightly-build [
 
     let assets = $latest.assets
         | get name
-        | parse --regex 'nu-\d\.\d+\.\d-(?<arch>[a-zA-Z0-9-_]*\..*)'
+        | where not ($it | str ends-with ".msi")
+        | parse --regex 'nu-\d\.\d+\.\d-(?<arch>[a-zA-Z0-9-_]*)\..*'
         | get arch
 
     let arch = if $interactive {
@@ -82,8 +83,8 @@ export def get-latest-nightly-build [
         _ => {
             error make --unspanned {
                 msg: (
-                    $"(ansi red_bold)unknown_archive_extension(ansi reset)\n"
-                  + $"unknown extension ($build.extension)"
+                    $"(ansi red_bold)unexpected_internal_error(ansi reset)\n"
+                  + $"unknown extension .($build.extension)"
                 )
                 help: "you'll have to figure out how to extract this archive ;)"
             }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -40,7 +40,11 @@ export def get-latest-nightly-build [
             },
         }
     } else {
-        error make --unspanned { msg: "TODO" }
+        match $nu.os-info.name {
+            "linux" => $"($nu.os-info.arch)-linux-musl-full",
+            "macos" => $"($nu.os-info.arch)-((sys).host.name | str downcase)",
+            "windows" => { error make --unspanned { msg: "TODO" } },
+        }
     }
 
     let target = $latest.assets | where name =~ $arch

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -1,3 +1,5 @@
+use std log
+
 # pull down the latest nightly build of Nushell
 #
 # this command will
@@ -65,13 +67,16 @@ export def get-latest-nightly-build [
         | parse --regex 'nu-(?<version>\d\.\d+\.\d)-(?<arch>[a-zA-Z0-9-_]*)\.(?<extension>.*)'
         | into record
 
+    log info $"pulling down (ansi default_dimmed)($target.name)(ansi reset)..."
     http get $target.browser_download_url | save --progress --force $dump_dir
 
     match $build.extension {
         "tar.gz" => {
+            log info "extracting nushell..."
             ^tar xvf $dump_dir --directory $nu.temp-path
         },
         "zip" => {
+            log info "extracting nushell..."
             ^unzip $dump_dir -d $nu.temp-path
         },
         _ => {
@@ -86,5 +91,6 @@ export def get-latest-nightly-build [
     }
 
     let binary = $dump_dir | str replace --regex $'\.($build.extension)$' '' | path join "nu"
+    log info "installing `nu`..."
     cp --force --verbose $binary ($install_dir | path expand)
 }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -2,47 +2,45 @@
 #
 # this command will
 # - get the metadata of the latest build of Nushell in the nightly repo
-# - filter the assets that match the search pattern `target`
 # - fuzzy-ask one of them or use the single match
 # - download the archive
 # - give some hints about the version and the hash and how to extract the archive
 export def get-latest-nightly-build [
-    target: string = "" # the target architecture, matches all of them by default
     --install-dir: path = "~/.local/bin/" # the directory where to install the `nu` binary
+    --interactive # ask for the architecture to install interactively
 ]: nothing -> nothing {
     let latest = http get https://api.github.com/repos/nushell/nightly/releases
         | sort-by published_at --reverse
         | first
 
-    let matches = $latest.assets
+    let assets = $latest.assets
         | get name
-        | where $it =~ $target
-        | where $it !~ 'msi'
-        | parse --regex 'nu-\d\.\d+\.\d-(?<arch>[a-zA-Z0-9-_]*)\..*'
+        | parse --regex 'nu-\d\.\d+\.\d-(?<arch>[a-zA-Z0-9-_]*\..*)'
         | get arch
 
-    let arch = match ($matches | length) {
-        0 => {
-            let span = metadata $target | get span
-            error make {
-                msg: $"(ansi red_bold)no_match(ansi reset)"
-                label: {
-                    text: $"no architecture matching this in ($latest.html_url)"
-                    start: $span.start
-                    end: $span.end
+    let arch = if $interactive {
+        match ($assets | length) {
+            0 => {
+                error make --unspanned {
+                    msg: (
+                          $"(ansi red_bold)unexpected_internal_error(ansi reset):\n"
+                        + "no nightly build..."
+                    )
                 }
-            }
-        },
-        1 => { $matches.0 },
-        _ => {
-            let choice = $matches | input list --fuzzy $"Please (ansi cyan)choose one architecture(ansi reset):"
-            if ($choice | is-empty) {
-                print "user chose to exit"
-                return
-            }
+            },
+            1 => { $assets.0 },
+            _ => {
+                let choice = $assets | input list --fuzzy $"Please (ansi cyan)choose one architecture(ansi reset):"
+                if ($choice | is-empty) {
+                    print "user chose to exit"
+                    return
+                }
 
-            $choice
-        },
+                $choice
+            },
+        }
+    } else {
+        error make --unspanned { msg: "TODO" }
     }
 
     let target = $latest.assets | where name =~ $arch
@@ -59,8 +57,7 @@ export def get-latest-nightly-build [
 
     let build = $target.name
         | parse --regex 'nu-(?<version>\d\.\d+\.\d)-(?<arch>[a-zA-Z0-9-_]*)\.(?<extension>.*)'
-        | first
-        | insert hash { $latest.tag_name | parse "nightly-{hash}" | get 0.hash }
+        | into record
 
     http get $target.browser_download_url | save --progress --force ($nu.temp-path | path join $target.name)
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -54,7 +54,7 @@ export def get-latest-nightly-build [
             }
         }
 
-        if $full and ($nu.os-info.name not-in ["linux", "macos", "windows"]) {
+        if $full and ($nu.os-info.arch not-in ["aarch64", "x86_64"]) {
             error make --unspanned {
                 msg: (
                     $"(ansi red_bold)invalid_options(ansi reset):\n"

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -1,12 +1,13 @@
 use std log
 
-# pull down the latest nightly build of Nushell
+# install the latest nightly build of Nushell
 #
 # this command will
 # - get the metadata of the latest build of Nushell in the nightly repo
-# - fuzzy-ask one of them or use the single match
+# - interactively ask for one of them or use architecture-specific defaults
 # - download the archive
-# - give some hints about the version and the hash and how to extract the archive
+# - extract the archive
+# - install the `nu` binary
 export def get-latest-nightly-build [
     --install-dir: path = "~/.local/bin/" # the directory where to install the `nu` binary
     --interactive # ask for the architecture to install interactively


### PR DESCRIPTION
as we've discussed @hustcer, here is an improved version of the `get-latest-nightly-build` command :innocent: 

there are some minor tweaks and refactoring.
apart from that, the core of these changes are
- the command will now extract and install the `nu` binary in `--install-dir`
- the default is a non-interactive install
  - `--interactive` will let the user chose among all the builds
  - otherwise, a default build will be chosen depending on the architecture
  - `--full` will install the fully-featured build of Nushell, i.e. with `dataframe` and `extra` enabled
  - `--musl` will install the MUSL build on `x86_64`

errors should be given when using an invalid set of options or when something bad happens internally :crossed_fingers: 