### PR TITLE
Run new container image tests before publishing

### DIFF
--- a/.github/workflows/nightly-alpine.yaml
+++ b/.github/workflows/nightly-alpine.yaml
@@ -50,6 +50,26 @@ jobs:
           $'BUILD_REF=(git rev-parse --short HEAD)(char nl)' o>> $env.GITHUB_ENV
           $'BUILD_DATE=(date now | format date %Y-%m-%dT%H:%M:%SZ)(char nl)' o>> $env.GITHUB_ENV
 
+      - name: Build Alpine Test Image
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
+        with:
+          push: false
+          load: true
+          context: ./docker
+          file: ./docker/Dockerfile
+          tags: nushell-test-image
+
+      - name: Test Alpine Image
+        run: |
+          echo "## Alpine Container Test Results" >> $GITHUB_STEP_SUMMARY
+          docker run --rm \
+            -v "$(pwd)/docker:/work" \
+            --env GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
+            nushell-test-image -c /work/test_docker.nu \
+            >> $GITHUB_STEP_SUMMARY
+
       - name: Build and Push Alpine Image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/release-nu-image.yaml
+++ b/.github/workflows/release-nu-image.yaml
@@ -57,6 +57,28 @@ jobs:
           $'NU_VERSION=($tagName)(char nl)' o>> $env.GITHUB_ENV
           $'BUILD_DATE=(date now | format date %Y-%m-%dT%H:%M:%SZ)(char nl)' o>> $env.GITHUB_ENV
 
+      - name: Build Debian Test Image
+        uses: docker/build-push-action@v6
+        if: ${{ matrix.base == 'debian' }}
+        env:
+          DOCKER_BUILD_SUMMARY: false
+        with:
+          push: false
+          load: true
+          context: ./docker
+          file: ./docker/debian.Dockerfile
+          tags: nushell-debian-test-image
+
+      - name: Test Debian Image
+        if: ${{ matrix.base == 'debian' }}
+        run: |
+          echo "## Debian Container Test Results" >> $GITHUB_STEP_SUMMARY
+          docker run --rm \
+            -v "$(pwd)/docker:/work" \
+            --env GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
+            nushell-debian-test-image -c /work/test_docker.nu \
+            >> $GITHUB_STEP_SUMMARY
+
       - name: Build and Push Debian Image
         uses: docker/build-push-action@v6
         if: ${{ matrix.base == 'debian' }}
@@ -74,6 +96,28 @@ jobs:
           tags: |
             ghcr.io/nushell/nushell:latest-bookworm
             ghcr.io/nushell/nushell:${{ env.NU_VERSION }}-bookworm
+
+      - name: Build Alpine Test Image
+        uses: docker/build-push-action@v6
+        if: ${{ matrix.base == 'alpine' }}
+        env:
+          DOCKER_BUILD_SUMMARY: false
+        with:
+          push: false
+          load: true
+          context: ./docker
+          file: ./docker/Dockerfile
+          tags: nushell-alpine-test-image
+
+      - name: Test Alpine Image
+        if: ${{ matrix.base == 'alpine' }}
+        run: |
+          echo "## Alpine Container Test Results" >> $GITHUB_STEP_SUMMARY
+          docker run --rm \
+            -v "$(pwd)/docker:/work" \
+            --env GITHUB_ACTIONS=${{ env.GITHUB_ACTIONS }} \
+            nushell-alpine-test-image -c /work/test_docker.nu \
+            >> $GITHUB_STEP_SUMMARY
 
       - name: Build and Push Alpine Image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
See test file added in [this PR](https://github.com/nushell/nushell/pull/14225).

I had to split the build and push to ensure we were not pushing any images that had failing tests, as per the recommendation from Docker [here](https://docs.docker.com/build/ci/github-actions/test-before-push).